### PR TITLE
Update minimum JupyterLab version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Note: for this to show anything, you need to enable cell timing in the notebook 
 "Jupyter" is a trademark of the NumFOCUS foundation, of which Project Jupyter is a part."
 ## Requirements
 
-- JupyterLab >= 2.0
+- JupyterLab >= 2.0.2
 
 ## Install
 


### PR DESCRIPTION
There was a bug in JLab 2.0.0 and 2.0.1 that prevented cell execution when recordTiming was enabled. You might be able to cut down on support issues if you just go ahead and require at least JLab 2.0.2.

See https://github.com/jupyterlab/jupyterlab/pull/8057 and https://github.com/jupyterlab/jupyterlab/issues/8056