### PR TITLE
PR: Add Binder with latest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 .ipynb_checkpoints
 *.tsbuildinfo
 .idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # jupyterlab-execute-time
-[![NPM version][npm-image]][npm-url] [![NPM DM][npm-dm-image]][npm-url] [![Build Status][travis-image]][travis-url]
 
+[![Binder][badge-binder]][binder]
+[![NPM version][npm-image]][npm-url] [![NPM DM][npm-dm-image]][npm-url] [![Build Status][travis-image]][travis-url]
 
 Display cell timings.
 
@@ -11,6 +12,7 @@ This is inspired by the notebook version [here](https://github.com/ipython-contr
 Note: for this to show anything, you need to enable cell timing in the notebook via Settings->Advanced Settings Editor->Notebook: `{"recordTiming": true}`
 
 "Jupyter" is a trademark of the NumFOCUS foundation, of which Project Jupyter is a part."
+
 ## Requirements
 
 - JupyterLab >= 2.0.2
@@ -51,7 +53,7 @@ jupyter lab --watch
 
 To test:
 
-```
+```bash
 yarn run test
 ```
 
@@ -72,6 +74,7 @@ This plugin was contributed back to the community by the [D. E. Shaw group](http
 </p>
 
 ## License
+
 This project is released under a [BSD-3-Clause license](https://github.com/deshaw/jupyterlab-execute-time/blob/master/LICENSE.txt).
 
 "Jupyter" is a trademark of the NumFOCUS foundation, of which Project Jupyter is a part.
@@ -83,3 +86,5 @@ This project is released under a [BSD-3-Clause license](https://github.com/desha
 [travis-url]: http://travis-ci.org/deshaw/jupyterlab-execute-time
 [travis-image]: https://secure.travis-ci.org/deshaw/jupyterlab-execute-time.png?branch=master
 
+[badge-binder]: https://mybinder.org/badge_logo.svg
+[binder]: https://mybinder.org/v2/gh/deshaw/jupyterlab-execute-time/master?urlpath=lab%2Ftree%2Fnotebooks%2Findex.ipynb

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+dependencies:
+  - jupyterlab>=2
+  - nodejs=12

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 D. E. Shaw & Co., L.P.
+# All rights reserved.
+# 
+# This project is released under a BSD-3-Clause license.
+#
+
+set -o errexit
+set -o xtrace
+
+node -v
+jupyter lab --version
+
+# Install the latest version, building from source currently has issues
+jupyter labextension install jupyterlab-execute-time --debug --minimize=False
+
+mkdir -p  ~/.jupyter/lab/user-settings/@jupyterlab/notebook-extension/
+echo '{"recordTiming": true}' > ~/.jupyter/lab/user-settings/@jupyterlab/notebook-extension/tracker.jupyterlab-settings

--- a/notebooks/index.ipynb
+++ b/notebooks/index.ipynb
@@ -1,0 +1,76 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Jupyterlab Execute Time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use Run->Run All Cells to see various states all at once in this notebook (use me in lab!)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from time import sleep"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sleep(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sleep(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note: for this to show anything, you need to enable cell timing in the notebook via Settings->Advanced Settings Editor->Notebook: `{\"recordTiming\": true}`\n",
+    "!cat ~/.jupyter/lab/user-settings/@jupyterlab/notebook-extension/tracker.jupyterlab-settings"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Fixes https://github.com/Quansight/deshaw/issues/50

It seems installing extensions from source is currently not working. The issues are similar to the ones reported on:
- https://gist.github.com/yuvipanda/eae14e5e9ac41186624a100128978a72
- https://github.com/jupyterlab/debugger/pull/344

I added, for now, binder to install from the latest version. 

Results can be seen on the branch build
https://mybinder.org/v2/gh/goanpeca/jupyterlab-execute-time/enh/add-binder?urlpath=lab%2Ftree%2Fnotebooks%2Findex.ipynb

![image](https://user-images.githubusercontent.com/3627835/85620507-80db6e00-b629-11ea-9fff-83390956850f.png)
