### PR TITLE
Minimal execution time and display on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### Added
 
 - The ability to specify the position of the execute time (`left`, `right` or `hover`) ([#16](https://github.com/deshaw/jupyterlab-execute-time/pull/16), [#17](https://github.com/deshaw/jupyterlab-execute-time/pull/17))
-- A minimal execution time can be specified. Only of cells which exceed this minimal, the execution time will be reported. ([#17](https://github.com/deshaw/jupyterlab-execute-time/pull/17))
 
 ## [1.0.0](https://github.com/deshaw/jupyterlab-execute-time/compare/v1.0.0...v1.0.0) (2020-04-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### Added
 
-- The ability to specify the position of the execute time (`left` or `right`) ([#16](https://github.com/deshaw/jupyterlab-execute-time/pull/16))
-- A minimal execution time can be specified. Only of cells which exceed this minimal, the execution time will be reported. ([#17](https://github.com/deshaw/jupyterlab-execute-time/pull/16))
+- The ability to specify the position of the execute time (`left`, `right` or `hover`) ([#16](https://github.com/deshaw/jupyterlab-execute-time/pull/16), [#17](https://github.com/deshaw/jupyterlab-execute-time/pull/17))
+- A minimal execution time can be specified. Only of cells which exceed this minimal, the execution time will be reported. ([#17](https://github.com/deshaw/jupyterlab-execute-time/pull/17))
 
 ## [1.0.0](https://github.com/deshaw/jupyterlab-execute-time/compare/v1.0.0...v1.0.0) (2020-04-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - The ability to specify the position of the execute time (`left` or `right`) ([#16](https://github.com/deshaw/jupyterlab-execute-time/pull/16))
+- A minimal execution time can be specified. Only of cells which exceed this minimal, the execution time will be reported. ([#17](https://github.com/deshaw/jupyterlab-execute-time/pull/16))
 
 ## [1.0.0](https://github.com/deshaw/jupyterlab-execute-time/compare/v1.0.0...v1.0.0) (2020-04-07)
 

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -21,12 +21,6 @@
       "description": "How to position the execution time. Possible values are: \"left\", \"right\" or \"hover\".",
       "default": "left",
       "enum": ["left", "right", "hover"]
-    },
-    "minimal_time": {
-      "type": "number",
-      "title": "Minimal execution time",
-      "description": "The minimal execution time (in ms) before it is reported.",
-      "default": 0
     }
   }
 }

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -18,9 +18,9 @@
     "positioning": {
       "type": "string",
       "title": "Positioning",
-      "description": "How to position the execution time. Possible values are: \"left\" or \"right\"",
+      "description": "How to position the execution time. Possible values are: \"left\", \"right\" or \"hover\".",
       "default": "left",
-      "enum": ["left", "right"]
+      "enum": ["left", "right", "hover"]
     },
     "minimal_time": {
       "type": "number",

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -21,6 +21,12 @@
       "description": "How to position the execution time. Possible values are: \"left\" or \"right\"",
       "default": "left",
       "enum": ["left", "right"]
+    },
+    "minimal_time": {
+      "type": "number",
+      "title": "Minimal execution time",
+      "description": "The minimal execution time (in ms) before it is reported.",
+      "default": 0
     }
   }
 }

--- a/src/ExecuteTimeWidget.ts
+++ b/src/ExecuteTimeWidget.ts
@@ -110,10 +110,7 @@ export default class ExecuteTimeWidget extends Widget {
    * @private
    */
   _removeExecuteNode(cell: CodeCell) {
-    const editorWidget = cell.inputArea.editorWidget;
-    const executionTimeNode = editorWidget.node.querySelector(
-      `.${EXECUTE_TIME_CLASS}`
-    );
+    const executionTimeNode = cell.node.querySelector(`.${EXECUTE_TIME_CLASS}`);
     if (executionTimeNode) {
       executionTimeNode.remove();
     }
@@ -133,13 +130,20 @@ export default class ExecuteTimeWidget extends Widget {
       'execution'
     ) as JSONObject;
     if (executionMetadata && JSONExt.isObject(executionMetadata)) {
-      const editorWidget = cell.inputArea.editorWidget;
-      let executionTimeNode: HTMLDivElement = editorWidget.node.querySelector(
+      let executionTimeNode: HTMLDivElement = cell.node.querySelector(
         `.${EXECUTE_TIME_CLASS}`
       );
+      const parentNode =
+        this._settings.positioning === 'hover'
+          ? cell.inputArea.node.parentNode
+          : cell.inputArea.editorWidget.node;
+
       if (!executionTimeNode) {
         executionTimeNode = document.createElement('div') as HTMLDivElement;
-        editorWidget.node.append(executionTimeNode);
+        parentNode.append(executionTimeNode);
+      } else if (executionTimeNode.parentNode !== parentNode) {
+        executionTimeNode.remove();
+        parentNode.append(executionTimeNode);
       }
 
       let positioning;
@@ -149,6 +153,9 @@ export default class ExecuteTimeWidget extends Widget {
           break;
         case 'right':
           positioning = 'right';
+          break;
+        case 'hover':
+          positioning = 'hover';
           break;
         default:
           console.error(

--- a/src/ExecuteTimeWidget.ts
+++ b/src/ExecuteTimeWidget.ts
@@ -9,6 +9,7 @@ import {
 } from '@jupyterlab/observables';
 import { Cell, CodeCell, ICellModel } from '@jupyterlab/cells';
 import { getTimeDiff, getTimeString } from './formatters';
+import { differenceInMilliseconds } from 'date-fns';
 
 export const PLUGIN_NAME = 'jupyterlab-execute-time';
 const EXECUTE_TIME_CLASS = 'execute-time';
@@ -21,6 +22,7 @@ export interface IExecuteTimeSettings {
   enabled: boolean;
   highlight: boolean;
   positioning: string;
+  minimal_time: number;
 }
 
 export default class ExecuteTimeWidget extends Widget {
@@ -122,7 +124,11 @@ export default class ExecuteTimeWidget extends Widget {
    * @param cell
    * @private
    */
-  _updateCodeCell(cell: CodeCell, disableHighlight: boolean) {
+  _updateCodeCell(
+    cell: CodeCell,
+    disableHighlight: boolean,
+    disableNestedCall: boolean = false
+  ) {
     const executionMetadata = cell.model.metadata.get(
       'execution'
     ) as JSONObject;
@@ -170,6 +176,22 @@ export default class ExecuteTimeWidget extends Widget {
         | null;
       const endTime = endTimeStr ? new Date(endTimeStr) : null;
 
+      const minimal_time = this._settings.minimal_time;
+      const runtime = differenceInMilliseconds(
+        endTime ? endTime : new Date(),
+        startTime
+      );
+      if (minimal_time > 0 && (!startTime || runtime < minimal_time)) {
+        executionTimeNode.className += ` ${EXECUTE_TIME_CLASS}-hidden`;
+        // Force update when cell is being executed but hasn't reached the minimal execution time yet
+        if (!disableNestedCall && startTime) {
+          setTimeout(() => {
+            // The hidden class should not directly be removed here; it's possible the cells metadata has changed.
+            this._updateCodeCell(cell, disableHighlight, true);
+          }, minimal_time);
+        }
+      }
+
       let msg = '';
       if (endTime) {
         msg = `Last executed at ${getTimeString(endTime)} in ${getTimeDiff(
@@ -202,6 +224,8 @@ export default class ExecuteTimeWidget extends Widget {
     this._settings.highlight = settings.get('highlight').composite as boolean;
     this._settings.positioning = settings.get('positioning')
       .composite as string;
+    this._settings.minimal_time = settings.get('minimal_time')
+      .composite as number;
 
     const cells = this._panel.context.model.cells;
     if (this._settings.enabled) {
@@ -227,6 +251,7 @@ export default class ExecuteTimeWidget extends Widget {
   private _settings: IExecuteTimeSettings = {
     enabled: false,
     highlight: true,
-    positioning: 'left'
+    positioning: 'left',
+    minimal_time: 0
   };
 }

--- a/style/executeTime.css
+++ b/style/executeTime.css
@@ -26,3 +26,7 @@
 .execute-time-positioning-right {
   text-align: right;
 }
+
+.execute-time-hidden {
+  display: none;
+}

--- a/style/executeTime.css
+++ b/style/executeTime.css
@@ -31,8 +31,7 @@
   display: none;
 }
 
-.jp-CodeCell:hover .execute-time.execute-time-positioning-hover,
-.jp-CodeCell.jp-mod-active .execute-time.execute-time-positioning-hover {
+.jp-Cell-inputWrapper:hover .execute-time.execute-time-positioning-hover {
   display: block;
   position: absolute;
   right: 0;

--- a/style/executeTime.css
+++ b/style/executeTime.css
@@ -19,14 +19,30 @@
   padding: 0 2px;
 }
 
-.execute-time-positioning-left {
+.execute-time.execute-time-positioning-left {
   text-align: left;
 }
 
-.execute-time-positioning-right {
+.execute-time.execute-time-positioning-right {
   text-align: right;
 }
 
-.execute-time-hidden {
+.execute-time.execute-time-positioning-hover {
+  display: none;
+}
+
+.jp-CodeCell:hover .execute-time.execute-time-positioning-hover,
+.jp-CodeCell.jp-mod-active .execute-time.execute-time-positioning-hover {
+  display: block;
+  position: absolute;
+  right: 0;
+  bottom: -1.25em;
+  border: 1px solid #cfcfcf;
+  border-width: 0 1px 1px 1px;
+  height: 1.25em;
+  z-index: 3;
+}
+
+.execute-time.execute-time-hidden {
   display: none;
 }


### PR DESCRIPTION

This PR adds two features, requested in #12 .
- Make it possible to only display the execution time on hover
![Selection_036](https://user-images.githubusercontent.com/9020072/97806951-67dd6c00-1c5e-11eb-8d4a-c8d94af20faf.png)
- Only report execution time when a certain minimal runtime has been exceeded
![Selection_039](https://user-images.githubusercontent.com/9020072/97807024-cdc9f380-1c5e-11eb-9e26-b9d2b6e32d07.png)

For this one new setting (`minimal_time`) was added and a new option for `positioning` (`hover`) is available.
![Selection_040](https://user-images.githubusercontent.com/9020072/97807083-200b1480-1c5f-11eb-85e6-cb04cb8621ee.png)
