### PR TITLE
Add helpful video explaining the note

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Display cell timings in Jupyter Lab
 
 This is inspired by the notebook version [here](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/blob/master/src/jupyter_contrib_nbextensions/nbextensions/execute_time).
 
-Note: for this to show anything, you need to enable cell timing in the notebook via Settings->Advanced Settings Editor->Notebook: `{"recordTiming": true}`. This is a notebook metadata setting and not a plugin setting. The plugin just displays this data.
+Note: for this to show anything, you need to enable cell timing in the notebook via Settings->Advanced Settings Editor->Notebook: `{"recordTiming": true}`. This is a notebook metadata setting and not a plugin setting. The plugin just displays this data. There is a helpful [video here](https://www.dropbox.com/s/3haak5srdntc79t/edit_settings.mp4?dl=0) .
 
 ## Requirements
 


### PR DESCRIPTION
Add an explanatory video as to how to update the settings  as in this line of the Readme
> Note: for this to show anything, you need to enable cell timing in the notebook via Settings->Advanced Settings Editor->Notebook: {"recordTiming": true}. This is a notebook metadata setting and not a plugin setting. The plugin just displays this data.