### PR TITLE
Fixes issue #38

### DIFF
--- a/src/ExecuteTimeWidget.ts
+++ b/src/ExecuteTimeWidget.ts
@@ -134,7 +134,9 @@ export default class ExecuteTimeWidget extends Widget {
 
       if (!executionTimeNode) {
         executionTimeNode = document.createElement('div') as HTMLDivElement;
-        parentNode.append(executionTimeNode);
+        if (!cell.inputHidden) {
+          parentNode.append(executionTimeNode);
+        }
       } else if (executionTimeNode.parentNode !== parentNode) {
         executionTimeNode.remove();
         parentNode.append(executionTimeNode);


### PR DESCRIPTION
adds logic to only append execute time node if parent cell input is visible. This fixes issue #38 where execute time nodes were stacking up when cells are collapsed and uncollapsed.