### PR TITLE
Fix build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.0.5](https://github.com/deshaw/jupyterlab-execute-time/compare/v2.0.4...v2.0.5) (2021-7-12)
+
+### Fixed
+
+- Issues with build
+
 ## [2.0.4](https://github.com/deshaw/jupyterlab-execute-time/compare/v2.0.3...v2.0.4) (2021-6-12)
 
 ### Fixed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,12 @@
 include LICENSE.txt
 include README.md
 include pyproject.toml
-include jupyter-config/jupyterlab_execute_time.json
+recursive-include jupyter-config *.json
 
 include package.json
 include install.json
 include ts*.json
+include yarn.lock
 
 graft jupyterlab_execute_time/labextension
 
@@ -14,6 +15,7 @@ graft src
 graft style
 prune **/node_modules
 prune lib
+prune binder
 
 # Patterns to exclude from any directory
 global-exclude *~

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-execute-time",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Display cell timings in Jupyter Lab",
   "keywords": [
     "jupyter",

--- a/setup.py
+++ b/setup.py
@@ -3,29 +3,29 @@ jupyterlab_execute_time setup.
 """
 import json
 from pathlib import Path
-
 import setuptools
+from jupyter_packaging import wrap_installers, npm_builder, get_data_files
 
 HERE = Path(__file__).parent.resolve()
 
 # The name of the project
 name = "jupyterlab_execute_time"
 
-lab_path = (HERE / name / "labextension")
+lab_path = HERE / name.replace("-", "_") / "labextension"
 
 # Representative files that should exist after a successful build
-ensured_targets = [
-    str(lab_path / "package.json"),
-    str(lab_path / "static/style.js")
-]
+ensured_targets = [str(lab_path / "package.json"), str(lab_path / "static/style.js")]
 
 labext_name = "jupyterlab-execute-time"
 
 data_files_spec = [
-    ("share/jupyter/labextensions/%s" % labext_name, str(lab_path), "**"),
-    ("share/jupyter/labextensions/%s" % labext_name, str(HERE), "install.json"),
+    (
+        "share/jupyter/labextensions/%s" % labext_name,
+        str(lab_path.relative_to(HERE)),
+        "**",
+    ),
+    ("share/jupyter/labextensions/%s" % labext_name, str("."), "install.json"),
 ]
-
 long_description = (HERE / "README.md").read_text()
 
 # Get the package info from package.json
@@ -41,9 +41,7 @@ setup_args = dict(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
-    install_requires=[
-        "jupyter_server>=1.6,<2"
-    ],
+    install_requires=["jupyter_server>=1.6,<2"],
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3.6",
@@ -61,19 +59,14 @@ setup_args = dict(
     ],
 )
 
-try:
-    from jupyter_packaging import (
-        wrap_installers,
-        npm_builder,
-        get_data_files
-    )
-    post_develop = npm_builder(
-        build_cmd="install:extension", source_dir="src", build_dir=lab_path
-    )
-    setup_args['cmdclass'] = wrap_installers(post_develop=post_develop, ensured_targets=ensured_targets)
-    setup_args['data_files'] = get_data_files(data_files_spec)
-except ImportError as e:
-    pass
+
+post_develop = npm_builder(
+    build_cmd="install:extension", source_dir="src", build_dir=lab_path
+)
+setup_args["cmdclass"] = wrap_installers(
+    post_develop=post_develop, ensured_targets=ensured_targets
+)
+setup_args["data_files"] = get_data_files(data_files_spec)
 
 if __name__ == "__main__":
     setuptools.setup(**setup_args)


### PR DESCRIPTION
The build was not clearly broken here, but in my release environment `jupyter_packaging` was missing so setup.py was missing data files. Moving importing from that package as a requirement for release. Other changes are to continue to keep up with cookie-cutter.

Fixes: https://github.com/deshaw/jupyterlab-execute-time/issues/44