### PR TITLE
Use built-in color variables

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -1,7 +1,7 @@
 /* Transition to highlight a cell change */
 @keyframes executeHighlight {
   from {
-    background-color:  var(--md-blue-100, #9fccff);
+    background-color: var(--md-blue-100, #9fccff);
   }
   to {
     background-color: var(--jp-cell-editor-background);

--- a/style/base.css
+++ b/style/base.css
@@ -1,7 +1,7 @@
 /* Transition to highlight a cell change */
 @keyframes executeHighlight {
   from {
-    background-color: #9fccff;
+    background-color:  var(--md-blue-100, #9fccff);
   }
   to {
     background-color: var(--jp-cell-editor-background);
@@ -13,9 +13,9 @@
   color: var(--jp-mirror-editor-variable-color);
   display: block;
   margin-top: 2px;
-  font-family: monospace;
+  font-family: var(--jp-code-font-family, monospace);
   font-size: 80%;
-  border-top: 1px solid #cfcfcf;
+  border-top: 1px solid var(--jp-cell-editor-border-color, #cfcfcf);
   padding: 0 2px;
 }
 
@@ -36,7 +36,7 @@
   position: absolute;
   right: 0;
   bottom: -1.25em;
-  border: 1px solid #cfcfcf;
+  border: 1px solid var(--jp-cell-editor-border-color, #cfcfcf);
   border-width: 0 1px 1px 1px;
   height: 1.25em;
   z-index: 3;


### PR DESCRIPTION
This PR uses JupyterLab built-in CSS variables to make it looks better with dark theme and other third-party themes:

![image](https://user-images.githubusercontent.com/96356/129661831-c669e1e9-cef7-46ec-9ce2-1cc4f10580b1.png)

![image](https://user-images.githubusercontent.com/96356/129661810-e88ae08e-1b3b-468a-b339-7eda03944344.png)
