### PR TITLE
Add a new settings: Text Contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 ## [2.1.1](https://github.com/deshaw/jupyterlab-execute-time/compare/v2.1.0...v2.1.1) (2022-3-4)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [2.1.1](https://github.com/deshaw/jupyterlab-execute-time/compare/v2.1.0...v2.1.1) (2022-3-4)
+## [2.2.0](https://github.com/deshaw/jupyterlab-execute-time/compare/v2.1.0...v2.2.0) (2022-3-4)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+
+## [2.1.1](https://github.com/deshaw/jupyterlab-execute-time/compare/v2.1.0...v2.1.1) (2022-3-4)
+
+### Added
+
+- Add a Text Contrast setting that allows users to select text color contrast.
+
 ## [2.1.0](https://github.com/deshaw/jupyterlab-execute-time/compare/v2.0.5...v2.1.0) (2021-10-1)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-execute-time",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Display cell timings in Jupyter Lab",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-execute-time",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Display cell timings in Jupyter Lab",
   "keywords": [
     "jupyter",

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -27,6 +27,13 @@
       "title": "Minimum time to display (s)",
       "description": "Minimum cell execution time in seconds to show timing info (0 means always)",
       "default": 0
+    },
+    "textContrast": {
+      "type": "string",
+      "title": "Text Contrast",
+      "description": "Text color contrast. Possible values are: \"high\", \"low\".",
+      "default": "high",
+      "enum": ["high", "low"]
     }
   }
 }

--- a/src/ExecuteTimeWidget.ts
+++ b/src/ExecuteTimeWidget.ts
@@ -23,6 +23,7 @@ export interface IExecuteTimeSettings {
   highlight: boolean;
   positioning: string;
   minTime: number;
+  textContrast: string;
 }
 
 export default class ExecuteTimeWidget extends Widget {
@@ -175,7 +176,8 @@ export default class ExecuteTimeWidget extends Widget {
           );
       }
       const positioningClass = `${EXECUTE_TIME_CLASS}-positioning-${this._settings.positioning}`;
-      executionTimeNode.className = `${EXECUTE_TIME_CLASS} ${positioningClass}`;
+      const textContrastClass = `${EXECUTE_TIME_CLASS}-contrast-${this._settings.textContrast}`;
+      executionTimeNode.className = `${EXECUTE_TIME_CLASS} ${positioningClass} ${textContrastClass}`;
 
       // More info about timing: https://jupyter-client.readthedocs.io/en/stable/messaging.html#messages-on-the-shell-router-dealer-channel
       // A cell is queued when the kernel has received the message
@@ -243,6 +245,8 @@ export default class ExecuteTimeWidget extends Widget {
     this._settings.positioning = settings.get('positioning')
       .composite as string;
     this._settings.minTime = settings.get('minTime').composite as number;
+    this._settings.textContrast = settings.get('textContrast')
+      .composite as string;
 
     const cells = this._panel.context.model.cells;
     if (this._settings.enabled) {
@@ -271,5 +275,6 @@ export default class ExecuteTimeWidget extends Widget {
     highlight: true,
     positioning: 'left',
     minTime: 0,
+    textContrast: 'high',
   };
 }

--- a/style/base.css
+++ b/style/base.css
@@ -10,13 +10,20 @@
 
 .execute-time {
   background-color: var(--jp-cell-editor-background);
-  color: var(--jp-mirror-editor-variable-color);
   display: block;
   margin-top: 2px;
   font-family: var(--jp-code-font-family, monospace);
   font-size: 80%;
   border-top: 1px solid var(--jp-cell-editor-border-color, #cfcfcf);
   padding: 0 2px;
+}
+
+.execute-time.execute-time-contrast-low {
+  color: var(--jp-ui-font-color3);
+}
+
+.execute-time.execute-time-contrast-high {
+  color: var(--jp-ui-font-color1);
 }
 
 .execute-time.execute-time-positioning-left {


### PR DESCRIPTION
In this PR, I would like to add a setting that enables users to select font color: high contrast or low contrast. See the example below.

<img width="889" alt="compare" src="https://user-images.githubusercontent.com/9190086/156685112-a90d8f2f-55e4-4a5c-8f4c-55722647b262.png">

I think a low contrast text (left version) is useful when users want this type of message less distractive.

I replaced the current CSS color variable used for the execution-time message (high contrast in this PR) from `--jp-mirror-editor-variable-color` to `--jp-ui-font-color1` because I think the message is a "UI element" rather than a "editor variable". But this introduces a minor change in the text color, so if you want to take care of the compatibility, I will restore the previous `--jp-mirror-editor-variable-color`.