### PR TITLE
Always opt into recordTiming when this plugin is started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Live execution time relative to last runtime. [#72](https://github.com/deshaw/jupyterlab-execute-time/pull/72)
 - Recent history of cell run timing via tooltip. [#72](https://github.com/deshaw/jupyterlab-execute-time/pull/72)
+- Auto opt-in to recoding cell timing for all notebooks. [#73](https://github.com/deshaw/jupyterlab-execute-time/pull/73)
 
 ## [2.2.0](https://github.com/deshaw/jupyterlab-execute-time/compare/v2.1.0...v2.2.0) (2022-03-04)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To install this package with [`conda`](https://docs.conda.io/en/latest/) run
 conda install -c conda-forge jupyterlab_execute_time
 ```
 
-Note: for this to show anything, you need to enable cell timing in the notebook via Settings->Advanced Settings Editor->Notebook: `{"recordTiming": true}`. This is a notebook metadata setting and not a plugin setting. The plugin just displays this data.
+Note: By default, if this extension is enabled, it will automatically change your settings to record timing in the notebook metadata when it is loaded. If this fails, you can do this manually via Settings->Advanced Settings Editor->Notebook: `{"recordTiming": true}`. This is a notebook metadata setting and not a plugin setting. The plugin just displays this data.
 
 ## Contributing
 

--- a/src/ExecuteTimeWidget.ts
+++ b/src/ExecuteTimeWidget.ts
@@ -40,12 +40,29 @@ export default class ExecuteTimeWidget extends Widget {
     super();
     this._panel = panel;
     this._tracker = tracker;
+    this._settingRegistry = settingRegistry;
 
     this.updateConnectedCell = this.updateConnectedCell.bind(this);
     settingRegistry.load(`${PLUGIN_NAME}:settings`).then(
       (settings: ISettingRegistry.ISettings) => {
         this._updateSettings(settings);
         settings.changed.connect(this._updateSettings.bind(this));
+
+        // If the plugin is enabled, force recoding of timing
+        // We only do this once (not on every settings update) in case the user tries to trun it off
+        if (settings.get('enabled').composite) {
+          this._settingRegistry
+            .load('@jupyterlab/notebook-extension:tracker')
+            .then(
+              (nbSettings: ISettingRegistry.ISettings) =>
+                nbSettings.set('recordTiming', true),
+              (err: Error) => {
+                console.error(
+                  `jupyterlab-execute-time: Could not force metadata recording: ${err}`
+                );
+              }
+            );
+        }
       },
       (err: Error) => {
         console.error(
@@ -346,6 +363,7 @@ export default class ExecuteTimeWidget extends Widget {
   } = {};
   private _tracker: INotebookTracker;
   private _panel: NotebookPanel;
+  private _settingRegistry: ISettingRegistry;
   private _settings: IExecuteTimeSettings = {
     enabled: false,
     highlight: true,


### PR DESCRIPTION
This is a common cause of confusion and is required for this extension to do anything.