### PR TITLE
Enable to use jupyter-server2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.3.1](https://github.com/deshaw/jupyterlab-execute-time/compare/v2.3.0...v2.3.1) (2022-12-27))
+
+### Fixed
+
+- Enable to use jupyter-server2.x.
+
 ## [2.3.0](https://github.com/deshaw/jupyterlab-execute-time/compare/v2.2.0...v2.3.0) (2022-11-03)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [2.3.1](https://github.com/deshaw/jupyterlab-execute-time/compare/v2.3.0...v2.3.1) (2022-12-27))
+## [2.3.1](https://github.com/deshaw/jupyterlab-execute-time/compare/v2.3.0...v2.3.1) (2022-12-28))
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-execute-time",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Display cell timings in Jupyter Lab",
   "keywords": [
     "jupyter",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup_args = dict(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
-    install_requires=["jupyter_server>=1.6,<2"],
+    install_requires=["jupyter_server>=1.6,<3"],
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3.6",


### PR DESCRIPTION
Recently, jupyter-server2 was released.

https://blog.jupyter.org/jupyter-server-2-0-is-released-121ac99e909a

Unfortunately, this extension is preventing pip from upgrading to jupyter-server2.
The extension still looks to work without any serious problems after upgrading to jupyter-server2.
So, I would like you to update the jupyter-server's version requirement.