### PR TITLE
feat: optional last executed date

### DIFF
--- a/schema/settings.json
+++ b/schema/settings.json
@@ -44,7 +44,7 @@
     "showDate": {
       "type": "boolean",
       "title": "Show Last Execution Date",
-      "description": "Show the date in browser timezone when the cell was last executed.",
+      "description": "Show the date of last cell execution.",
       "default": true
     },
     "historyCount": {

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -41,6 +41,12 @@
       "description": "Show the current execution time (last execution time) as a cell executes.",
       "default": true
     },
+    "showDate": {
+      "type": "boolean",
+      "title": "Show Last Execution Date",
+      "description": "Show the date in browser timezone when the cell was last executed.",
+      "default": true
+    },
     "historyCount": {
       "type": "number",
       "title": "History of Cell Execution Time",

--- a/src/ExecuteTimeWidget.ts
+++ b/src/ExecuteTimeWidget.ts
@@ -279,7 +279,7 @@ export default class ExecuteTimeWidget extends Widget {
           )} in ${executionTime}`;
           msg = 'Last executed';
           if (this._settings.showDate) {
-            msg += ` at ${getTimeString(endTime)}`;
+            msg += ` at ${getTimeString(endTime, this._settings.dateFormat)}`;
           }
           msg += ` in ${executionTime}`;
         }

--- a/src/ExecuteTimeWidget.ts
+++ b/src/ExecuteTimeWidget.ts
@@ -29,6 +29,7 @@ export interface IExecuteTimeSettings {
   minTime: number;
   textContrast: string;
   showLiveExecutionTime: boolean;
+  showDate: boolean;
   historyCount: number;
   dateFormat: string;
 }
@@ -276,6 +277,11 @@ export default class ExecuteTimeWidget extends Widget {
             endTime,
             this._settings.dateFormat
           )} in ${executionTime}`;
+          msg = 'Last executed';
+          if (this._settings.showDate) {
+            msg += ` at ${getTimeString(endTime)}`;
+          }
+          msg += ` in ${executionTime}`;
         }
       } else if (startTime) {
         if (this._settings.showLiveExecutionTime) {
@@ -353,6 +359,7 @@ export default class ExecuteTimeWidget extends Widget {
       .composite as string;
     this._settings.showLiveExecutionTime = settings.get('showLiveExecutionTime')
       .composite as boolean;
+    this._settings.showDate = settings.get('showDate').composite as boolean;
     this._settings.historyCount = settings.get('historyCount')
       .composite as number;
 
@@ -397,6 +404,7 @@ export default class ExecuteTimeWidget extends Widget {
     minTime: 0,
     textContrast: 'high',
     showLiveExecutionTime: true,
+    showDate: true,
     historyCount: 5,
     dateFormat: 'yyy-MM-dd HH:mm:ss',
   };


### PR DESCRIPTION
add a `showDate` privacy setting that allows to hide the last executed date.

with it enabled, `Last executed at <date> in <time>` becomes `Last executed in <time>`.

it allows to safely share screenshots of your notebooks without leaking the timezone you are in.