### PR TITLE
Use execution failure timing information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Make display of last execution date optional [#94](https://github.com/deshaw/jupyterlab-execute-time/pull/94)
 - Enable defining custom date format [#93](https://github.com/deshaw/jupyterlab-execute-time/pull/93)
+- Support execution failure timing information (in JupyterLab 4.1+) [#100](https://github.com/deshaw/jupyterlab-execute-time/pull/100)
 
 ## [3.0.1](https://github.com/deshaw/jupyterlab-execute-time/compare/v3.0.0...v3.0.1) (2023-08-02)
 


### PR DESCRIPTION
## References

Fixes https://github.com/deshaw/jupyterlab-execute-time/issues/84

Depends on https://github.com/jupyterlab/jupyterlab/pull/15285 which targets JupyterLab 4.1

## Code changes

- Aborts updates of live execution when new key `execution_failed` is detected in cell timing metadata 
- Adds new status to display when cell execution failed due to kernel restart

## User-facing changes

| Before | After |
|--------|--------|
| ![execute-before](https://github.com/jupyterlab/jupyterlab/assets/5832902/b1eb1628-0d0f-4cf5-9cdb-902b981ba0c6) | ![execute-after](https://github.com/jupyterlab/jupyterlab/assets/5832902/1214f257-8af5-415e-b26d-3f638d2d1cfd) | 