### PR TITLE
Fix node attachment issue with windowed notebook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Make display of last execution date optional [#94](https://github.com/deshaw/jupyterlab-execute-time/pull/94)
 - Enable defining custom date format [#93](https://github.com/deshaw/jupyterlab-execute-time/pull/93)
 
+### Fixed
+
+- Fix node attachment issue with windowed notebook [#102](https://github.com/deshaw/jupyterlab-execute-time/pull/102)
+
 ## [3.0.1](https://github.com/deshaw/jupyterlab-execute-time/compare/v3.0.0...v3.0.1) (2023-08-02)
 
 ### Changed

--- a/src/ExecuteTimeWidget.ts
+++ b/src/ExecuteTimeWidget.ts
@@ -427,7 +427,7 @@ export default class ExecuteTimeWidget extends Widget {
   }
 
   /**
-   * Increase counter of of updates ever scheduled for a given `cell`.
+   * Increase counter of updates ever scheduled for a given `cell`.
    * Returns the current counter value for the given `cell`.
    */
   private _increaseUpdateCounter(cell: CodeCell): number {
@@ -437,7 +437,7 @@ export default class ExecuteTimeWidget extends Widget {
   }
 
   /**
-   * The counter of of updates ever scheduled for each existing cell.
+   * The counter of updates ever scheduled for each existing cell.
    */
   private _updateCounter: WeakMap<CodeCell, number> = new WeakMap();
   private _cellSlotMap: {


### PR DESCRIPTION
Fixes #101

- [x] Wait for cell to be attached to DOM (enter the viewport) before querying the DOM
- [x] Cancel the old update requests when a new one arrives for cells which are out of viewport