### PR TITLE
Fix font size of the execute time element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Enable defining custom date format [#93](https://github.com/deshaw/jupyterlab-execute-time/pull/93)
 - Support execution failure timing information (in JupyterLab 4.1+) [#100](https://github.com/deshaw/jupyterlab-execute-time/pull/100)
 
+### Fixed
+
+- Font size of the execute time indicator [#103](https://github.com/deshaw/jupyterlab-execute-time/pull/103)
+
 ## [3.0.1](https://github.com/deshaw/jupyterlab-execute-time/compare/v3.0.0...v3.0.1) (2023-08-02)
 
 ### Changed

--- a/style/base.css
+++ b/style/base.css
@@ -14,7 +14,7 @@
   justify-content: space-between;
   margin-top: 2px;
   font-family: var(--jp-code-font-family, monospace);
-  font-size: 80%;
+  font-size: calc(0.8*14px);
   border-top: 1px solid var(--jp-cell-editor-border-color, #cfcfcf);
   padding: 0 2px;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -14,7 +14,7 @@
   justify-content: space-between;
   margin-top: 2px;
   font-family: var(--jp-code-font-family, monospace);
-  font-size: calc(0.8*14px);
+  font-size: 86%;
   border-top: 1px solid var(--jp-cell-editor-border-color, #cfcfcf);
   padding: 0 2px;
 }


### PR DESCRIPTION
This issue arose due to jupyterlab removing dependence on blueprintjs which was setting the font size to `14px`. After removing blueprintjs, the new font size was being set to 80% of `--jp-ui-font-size1` whose value is 13px (jupyterlab/jupyterlab#12331)

I have reset the font size to the previous value to fix the readability issue.