### PR TITLE
Fix execute time not showing up after moving a cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.1 (unreleased)
+
+### Fixed
+
+- Fix execute time not showing up after moving a cell [#109](https://github.com/deshaw/jupyterlab-execute-time/pull/109)
+
 ## [3.1.0](https://github.com/deshaw/jupyterlab-execute-time/compare/v3.0.1...v3.1.0) (2023-11-06)
 
 ### Added

--- a/ui-tests/notebooks/Simple_notebook.ipynb
+++ b/ui-tests/notebooks/Simple_notebook.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6ba4d4d-2fc5-480d-8f6b-d80e44f51dda",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from time import sleep"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec671046-8e9f-409e-8b8e-708154c0ac10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sleep(0.01)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "000acc20-b975-49b0-905a-b3b11fbfb349",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sleep(0.01)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ui-tests/tests/cell_operations.spec.ts
+++ b/ui-tests/tests/cell_operations.spec.ts
@@ -1,0 +1,33 @@
+import { expect, galata, test } from '@jupyterlab/galata';
+import { openNotebook, cleanup } from './utils';
+
+const NOTEBOOK_ID = '@jupyterlab/notebook-extension:tracker';
+
+test.describe('Cell operations', () => {
+  test.use({
+    mockSettings: {
+      ...galata.DEFAULT_SETTINGS,
+      [NOTEBOOK_ID]: {
+        ...galata.DEFAULT_SETTINGS[NOTEBOOK_ID],
+        windowingMode: 'defer',
+      },
+    },
+  });
+  test.beforeEach(openNotebook('Simple_notebook.ipynb'));
+  test.afterEach(cleanup);
+
+  test('Add and move a cell', async ({ page }) => {
+    await page.notebook.run();
+    // There are three cells, there should be three widgets
+    expect(await page.locator('.execute-time').count()).toBe(3);
+    // Add a new cell
+    await page.notebook.addCell('code', 'sleep(0.01)');
+    // Move the added cell up (fourth, index three)
+    await page.notebook.selectCells(3);
+    await page.menu.clickMenuItem('Edit>Move Cell Up');
+    // Run the added cell
+    await page.notebook.runCell(2, true);
+    // Four cells should now have the widget
+    expect(await page.locator('.execute-time').count()).toBe(4);
+  });
+});


### PR DESCRIPTION
### References

Fixes #108

### Code changes

- Add a test ensuring that the extension renders a timing widget when running a cell that has been moved
- Listen to cell's shared model disposal signal to de-register a cell before the problematic `CellList.changed` signal emits

### User-facing changes

| Before | After |
|--|--|
| ![before](https://github.com/deshaw/jupyterlab-execute-time/assets/5832902/e78e8916-3765-4801-9edc-36c09af19644) | ![after](https://github.com/deshaw/jupyterlab-execute-time/assets/5832902/34146e55-1fcc-4902-b7ea-fe20a07cb51b) |

### Backwards-incompatible changes

None