### PR TITLE
Enable test retires on CI

### DIFF
--- a/ui-tests/playwright.config.js
+++ b/ui-tests/playwright.config.js
@@ -11,4 +11,5 @@ module.exports = {
     timeout: 120 * 1000,
     reuseExistingServer: !process.env.CI,
   },
+  retries: process.env.CI ? 1 : 0
 };


### PR DESCRIPTION
This should help alleviate most spawning issues due to concurrent execution or temporary runner fault, as seen in https://github.com/deshaw/jupyterlab-execute-time/actions/runs/7700936310/attempts/1 which failed and https://github.com/deshaw/jupyterlab-execute-time/actions/runs/7700936310/attempts/2 which succeeded.