### PR TITLE
Upgrade actions to versions using Node.js 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-       node-version: '18.x'
+       node-version: '20.x'
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
         architecture: 'x64'
@@ -44,7 +44,7 @@ jobs:
         pip uninstall -y "jupyterlab-execute-time" jupyterlab
 
     - name: Upload extension packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: extension-artifacts
         path: dist/jupyterlab_execute_time*
@@ -55,13 +55,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
         architecture: 'x64'
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: extension-artifacts
     - name: Install and Test
@@ -87,28 +87,28 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-       node-version: '18.x'
+       node-version: '20.x'
 
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
         architecture: 'x64'
 
     - name: Download extension package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: extension-artifacts
 
     - name: Install the extension
       run: |
         set -eux
-        python -m pip install "jupyterlab>=4.1.0rc1,<5" jupyterlab_execute_time*.whl
+        python -m pip install "jupyterlab>=4.1.0,<5" jupyterlab_execute_time*.whl
 
     - name: Install dependencies
       working-directory: ui-tests
@@ -118,7 +118,7 @@ jobs:
       run: jlpm install
 
     - name: Set up browser cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ github.workspace }}/pw-browsers
@@ -135,7 +135,7 @@ jobs:
 
     - name: Upload Playwright Test report
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: jupyterlab_execute_time-playwright-tests
         path: |

--- a/.github/workflows/update-integration-tests.yml
+++ b/.github/workflows/update-integration-tests.yml
@@ -34,7 +34,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
-        run: python -m pip install -U "jupyterlab>=4.1.0rc1,<5"
+        run: python -m pip install -U "jupyterlab>=4.1.0,<5"
 
       - name: Install extension
         run: |


### PR DESCRIPTION
- Upgrade actions to versions using Node.js 20; this removes warning on action runs; GitHub plans to remove support for old Node.js versions from the latest runners [in Spring 2024](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) so technically the window opens next week
  | Before | After |
  | -- |--|
  |  ![Screenshot from 2024-03-11 16-12-25](https://github.com/krassowski/jupyterlab-execute-time/assets/5832902/fd9bea6b-67e4-447b-88e8-0f753451473e) | ![Screenshot from 2024-03-11 16-21-07](https://github.com/deshaw/jupyterlab-execute-time/assets/5832902/db6b5a13-5676-4c77-83e3-d311c44d1ed4) |
- Update pin for JupyterLab as 4.1 is now released