### PR TITLE
Fix extension not showing up in the Settings Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add an option to show the cell outputs per second [#116](https://github.com/deshaw/jupyterlab-execute-time/pull/116)
 
+### Fixed
+
+- Fix extension not showing up in the Settings Editor [#120](https://github.com/deshaw/jupyterlab-execute-time/pull/120)
+
 ## [3.1.2](https://github.com/deshaw/jupyterlab-execute-time/compare/v3.1.0...v3.1.2) (2024-02-14)
 
 ### Fixed

--- a/src/ExecuteTimeWidget.ts
+++ b/src/ExecuteTimeWidget.ts
@@ -39,41 +39,16 @@ export default class ExecuteTimeWidget extends Widget {
   constructor(
     panel: NotebookPanel,
     tracker: INotebookTracker,
-    settingRegistry: ISettingRegistry
+    settings: ISettingRegistry.ISettings
   ) {
     super();
     this._panel = panel;
     this._tracker = tracker;
-    this._settingRegistry = settingRegistry;
 
     this.updateConnectedCell = this.updateConnectedCell.bind(this);
-    settingRegistry.load(`${PLUGIN_NAME}:settings`).then(
-      (settings: ISettingRegistry.ISettings) => {
-        this._updateSettings(settings);
-        settings.changed.connect(this._updateSettings.bind(this));
 
-        // If the plugin is enabled, force recording of timing
-        // We only do this once (not on every settings update) in case the user tries to turn it off
-        if (settings.get('enabled').composite) {
-          this._settingRegistry
-            .load('@jupyterlab/notebook-extension:tracker')
-            .then(
-              (nbSettings: ISettingRegistry.ISettings) =>
-                nbSettings.set('recordTiming', true),
-              (err: Error) => {
-                console.error(
-                  `jupyterlab-execute-time: Could not force metadata recording: ${err}`
-                );
-              }
-            );
-        }
-      },
-      (err: Error) => {
-        console.error(
-          `jupyterlab-execute-time: Could not load settings, so did not active ${PLUGIN_NAME}: ${err}`
-        );
-      }
-    );
+    this._updateSettings(settings);
+    settings.changed.connect(this._updateSettings.bind(this));
   }
 
   /**
@@ -517,7 +492,6 @@ export default class ExecuteTimeWidget extends Widget {
   } = {};
   private _tracker: INotebookTracker;
   private _panel: NotebookPanel;
-  private _settingRegistry: ISettingRegistry;
   private _settings: IExecuteTimeSettings = {
     enabled: false,
     highlight: true,

--- a/ui-tests/tests/settings_editor.spec.ts
+++ b/ui-tests/tests/settings_editor.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@jupyterlab/galata';
+
+test.describe('Settings Editor', () => {
+  test('Execute Time show up in the Settings Editor', async ({ page }) => {
+    await page.evaluate(async () => {
+      await window.jupyterapp.commands.execute('settingeditor:open');
+    });
+    const plugin = page.locator(
+      '.jp-PluginList .jp-PluginList-entry >> text="Execute Time"'
+    );
+
+    expect(plugin).toHaveCount(1);
+  });
+});

--- a/ui-tests/tests/settings_editor.spec.ts
+++ b/ui-tests/tests/settings_editor.spec.ts
@@ -9,6 +9,7 @@ test.describe('Settings Editor', () => {
       '.jp-PluginList .jp-PluginList-entry >> text="Execute Time"'
     );
 
+    await plugin.waitFor();
     expect(plugin).toHaveCount(1);
   });
 });


### PR DESCRIPTION
Fixes #119

- [x] adds a test case (first commit should fail)
- [x] moves the initial setting loading to plugin `activate` function to avoid the delay in loading the settings until the first notebook is opened; this also improves the performance when opening notebook as the loading logic is not unnecessarily invoked multiple times anymore
- [x] adds changelog entry