### PR TITLE
Add CSS variables for background colors

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -1,15 +1,20 @@
+:root {
+  --jp-execute-time-highlight: var(--jp-brand-color3, #bbdefb);
+  --jp-execute-time-background: var(--jp-cell-editor-background);
+}
+
 /* Transition to highlight a cell change */
 @keyframes executeHighlight {
   from {
-    background-color: var(--md-blue-100, #9fccff);
+    background-color: var(--jp-execute-time-highlight);
   }
   to {
-    background-color: var(--jp-cell-editor-background);
+    background-color: var(--jp-execute-time-background);
   }
 }
 
 .execute-time {
-  background-color: var(--jp-cell-editor-background);
+  background-color: var(--jp-execute-time-background);
   display: flex;
   justify-content: space-between;
   margin-top: 2px;


### PR DESCRIPTION
Closes #124 

---

Hi! 👋 

As per the discussion on #124, here is a proposal to include two CSS variables to style the (animated) background colors for this extension. The highlight color fallback has also been updated. Let me know what you think, please!

https://github.com/user-attachments/assets/8533b638-32ae-41b0-9cd0-126d20c417c6

<img width="1582" alt="Screenshot 2024-07-15 at 18 23 58" src="https://github.com/user-attachments/assets/d29b243f-bdcd-4992-867b-6ba5b202e5bc">