### PR TITLE
Use single source of truth for package version, update date in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.3.0](https://github.com/deshaw/jupyterlab-execute-time/compare/v3.2.0...v3.3.0) (unreleased)
+## [3.3.0](https://github.com/deshaw/jupyterlab-execute-time/compare/v3.2.0...v3.3.0) (2025-12-23)
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "hatchling",
     "jupyterlab~=4.0.0",
+    "hatch-nodejs-version>=0.3.2",
 ]
 build-backend = "hatchling.build"
 
@@ -36,13 +37,16 @@ classifiers = [
 dependencies = [
     "jupyterlab>=4,<5",
 ]
-version = "3.2.0"
+dynamic = ["version"]
 
 [project.license]
 file = "LICENSE.txt"
 
 [project.urls]
 Homepage = "https://github.com/deshaw/jupyterlab-execute-time"
+
+[tool.hatch.version]
+source = "nodejs"
 
 [tool.hatch.build.targets.wheel.shared-data]
 "jupyterlab_execute_time/labextension/static" = "share/jupyter/labextensions/jupyterlab-execute-time/static"
@@ -96,10 +100,6 @@ regex = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<channel>a|b|rc|
 [tool.tbump.git]
 message_template = "Bump to {new_version}"
 tag_template = "v{new_version}"
-
-[[tool.tbump.file]]
-src = "pyproject.toml"
-version_template = "version = \"{major}.{minor}.{patch}{channel}{release}\""
 
 [[tool.tbump.file]]
 src = "package.json"


### PR DESCRIPTION
- Use single source of truth for package version
- Update date in changelog for v3.3.0