### PR TITLE
Add timezone setting to render timestamps in a fixed time zone

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "schemaDir": "schema",
     "outputDir": "jupyterlab_execute_time/labextension",
     "sharedPackages": {
-      "date-fns-tz": false
+      "@date-fns/tz": false
     }
   },
   "main": "lib/index.js",
@@ -63,6 +63,7 @@
     "lib0": "0.2.111"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.4.1",
     "@jupyterlab/application": "^4.5.0",
     "@jupyterlab/apputils": "^4.5.0",
     "@jupyterlab/cells": "^4.5.0",
@@ -72,8 +73,7 @@
     "@jupyterlab/settingregistry": "^4.5.0",
     "@lumino/coreutils": "^2.0.0-rc.1",
     "@lumino/widgets": "^2.0.0-rc.1",
-    "date-fns": "^2.29.3",
-    "date-fns-tz": "^2.0.0"
+    "date-fns": "^4.1.0"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-execute-time",
-  "version": "3.3.0",
+  "version": "3.3.0+loft.1",
   "description": "Display cell timings in Jupyter Lab",
   "keywords": [
     "jupyter",
@@ -26,7 +26,10 @@
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema",
-    "outputDir": "jupyterlab_execute_time/labextension"
+    "outputDir": "jupyterlab_execute_time/labextension",
+    "sharedPackages": {
+      "date-fns-tz": false
+    }
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -69,7 +72,8 @@
     "@jupyterlab/settingregistry": "^4.5.0",
     "@lumino/coreutils": "^2.0.0-rc.1",
     "@lumino/widgets": "^2.0.0-rc.1",
-    "date-fns": "^2.29.3"
+    "date-fns": "^2.29.3",
+    "date-fns-tz": "^2.0.0"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-execute-time",
-  "version": "3.3.0+loft.1",
+  "version": "3.3.0",
   "description": "Display cell timings in Jupyter Lab",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.3.0",
-    "typescript": "~5.0.2",
+    "typescript": "~5.4.0",
     "yjs": "^13.5.0"
   },
   "styleModule": "style/index.js"

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -2,6 +2,7 @@
   "title": "Execute Time",
   "type": "object",
   "additionalProperties": true,
+  "jupyter.lab.transform": true,
   "properties": {
     "enabled": {
       "type": "boolean",
@@ -63,7 +64,7 @@
     "timezone": {
       "type": "string",
       "title": "Timezone",
-      "description": "IANA timezone name (e.g. \"UTC\", \"America/New_York\") used to render every timestamp. Leave empty to use the browser's local timezone.",
+      "description": "IANA timezone used to render every timestamp. Leave empty to use the browser's local timezone. The dropdown options are populated at runtime from `Intl.supportedValuesOf('timeZone')`; any IANA name is accepted via JSON editing.",
       "default": ""
     },
     "showOutputsPerSecond": {

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -60,6 +60,12 @@
       "default": "yyy-MM-dd HH:mm:ss",
       "pattern": "[yGuqQMLwdeEcabBhHkKmsSzOxX\\W].*"
     },
+    "timezone": {
+      "type": "string",
+      "title": "Timezone",
+      "description": "IANA timezone name (e.g. \"UTC\", \"America/New_York\") used to render every timestamp. Leave empty to use the browser's local timezone.",
+      "default": ""
+    },
     "showOutputsPerSecond": {
       "type": "boolean",
       "title": "Show Outputs Per Second",

--- a/src/ExecuteTimeWidget.ts
+++ b/src/ExecuteTimeWidget.ts
@@ -32,6 +32,7 @@ export interface IExecuteTimeSettings {
   showDate: boolean;
   historyCount: number;
   dateFormat: string;
+  timezone: string;
   showOutputsPerSecond: boolean;
 }
 
@@ -324,7 +325,11 @@ export default class ExecuteTimeWidget extends Widget {
 
           msg = failed ? 'Failed' : 'Last executed';
           if (this._settings.showDate) {
-            msg += ` at ${getTimeString(endTime, this._settings.dateFormat)}`;
+            msg += ` at ${getTimeString(
+              endTime,
+              this._settings.dateFormat,
+              this._settings.timezone
+            )}`;
           }
           msg += ` in ${executionTime}`;
 
@@ -375,7 +380,8 @@ export default class ExecuteTimeWidget extends Widget {
         }
         msg = `Execution started at ${getTimeString(
           startTime,
-          this._settings.dateFormat
+          this._settings.dateFormat,
+          this._settings.timezone
         )}`;
       } else if (queuedTime) {
         const lastRunTime = executionTimeNode.getAttribute(
@@ -387,7 +393,8 @@ export default class ExecuteTimeWidget extends Widget {
 
         msg = `Execution queued at ${getTimeString(
           queuedTime,
-          this._settings.dateFormat
+          this._settings.dateFormat,
+          this._settings.timezone
         )}`;
       }
       if (executionTimeNode.textContent !== msg) {
@@ -440,6 +447,8 @@ export default class ExecuteTimeWidget extends Widget {
         formatValidationResult.message
       );
     }
+
+    this._settings.timezone = settings.get('timezone').composite as string;
 
     this._settings.showOutputsPerSecond = settings.get('showOutputsPerSecond')
       .composite as boolean;
@@ -527,6 +536,7 @@ export default class ExecuteTimeWidget extends Widget {
     showDate: true,
     historyCount: 5,
     dateFormat: 'yyy-MM-dd HH:mm:ss',
+    timezone: '',
     showOutputsPerSecond: false,
   };
 }

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -1,5 +1,5 @@
 import { differenceInMilliseconds, format } from 'date-fns';
-import { formatInTimeZone } from 'date-fns-tz';
+import { tz } from '@date-fns/tz';
 
 export interface IFormatValidationResult {
   isValid: boolean;
@@ -36,7 +36,7 @@ export const getTimeString = (
   timezone = ''
 ): string => {
   return timezone
-    ? formatInTimeZone(date, timezone, dateFormat)
+    ? format(date, dateFormat, { in: tz(timezone) })
     : format(date, dateFormat);
 };
 

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -1,4 +1,5 @@
 import { differenceInMilliseconds, format } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 
 export interface IFormatValidationResult {
   isValid: boolean;
@@ -31,9 +32,12 @@ export const validateDateFormat = (
 
 export const getTimeString = (
   date: Date,
-  dateFormat = 'yyy-MM-dd HH:mm:ss'
+  dateFormat = 'yyy-MM-dd HH:mm:ss',
+  timezone = ''
 ): string => {
-  return format(date, dateFormat);
+  return timezone
+    ? formatInTimeZone(date, timezone, dateFormat)
+    : format(date, dateFormat);
 };
 
 export const getTimeDiff = (end: Date, start: Date): string => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,34 +43,27 @@ const extension: JupyterFrontEndPlugin<void> = {
   ) => {
     const pluginId = `${PLUGIN_NAME}:settings`;
 
-    // Populate the `timezone` dropdown with the IANA timezones the host
-    // runtime supports. Done as a `fetch` transform so the choices are
-    // baked into the schema before the settings UI renders it. Note that
-    // we intentionally only add `oneOf` here (not in the static schema);
-    // the server validates writes against the static schema, so leaving
-    // it as just `type: "string"` accepts any IANA name on save.
+    // Inject the list of IANA timezones supported by the runtime into the
+    // `timezone` schema's `oneOf` so the settings editor renders it as a
+    // dropdown. The static schema only declares `type: "string"` so the
+    // server (which validates writes against the static schema) keeps
+    // accepting any IANA name; the constrained list lives only in this
+    // client-side, fetch-phase transform.
     settingRegistry.transform(pluginId, {
-      fetch: plugin => {
-        // `Intl.supportedValuesOf` lives in lib.es2022.intl; cast narrowly
-        // instead of bumping the project-wide tsconfig.
-        const supportedValuesOf = (
-          Intl as { supportedValuesOf?: (key: 'timeZone') => string[] }
-        ).supportedValuesOf;
-        // Always include UTC: some ICU builds omit it from the canonical
-        // list (returning only `Etc/UTC`), which would prevent the most
-        // common choice from appearing in the dropdown.
+      fetch: (plugin) => {
+        // `Intl.supportedValuesOf('timeZone')` is not consistent across JS
+        // engines about exposing the bare `UTC` alias (some return only
+        // `Etc/UTC`). Prepend it ourselves and dedupe so the most common
+        // choice is always selectable.
         const zones = Array.from(
-          new Set([
-            'UTC',
-            ...(supportedValuesOf ? supportedValuesOf('timeZone') : []),
-          ])
+          new Set(['UTC', ...Intl.supportedValuesOf('timeZone')])
         ).sort();
         const properties = plugin.schema.properties ?? {};
         properties.timezone = {
           ...properties.timezone,
           oneOf: [
             { type: 'string', const: '', title: 'Browser local time' },
-            ...zones.map(zone => ({
+            ...zones.map((zone) => ({
               type: 'string',
               const: zone,
               title: zone,

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,9 +41,50 @@ const extension: JupyterFrontEndPlugin<void> = {
     tracker: INotebookTracker,
     settingRegistry: ISettingRegistry
   ) => {
+    const pluginId = `${PLUGIN_NAME}:settings`;
+
+    // Populate the `timezone` dropdown with the IANA timezones the host
+    // runtime supports. Done as a `fetch` transform so the choices are
+    // baked into the schema before the settings UI renders it. Note that
+    // we intentionally only add `oneOf` here (not in the static schema);
+    // the server validates writes against the static schema, so leaving
+    // it as just `type: "string"` accepts any IANA name on save.
+    settingRegistry.transform(pluginId, {
+      fetch: plugin => {
+        // `Intl.supportedValuesOf` lives in lib.es2022.intl; cast narrowly
+        // instead of bumping the project-wide tsconfig.
+        const supportedValuesOf = (
+          Intl as { supportedValuesOf?: (key: 'timeZone') => string[] }
+        ).supportedValuesOf;
+        // Always include UTC: some ICU builds omit it from the canonical
+        // list (returning only `Etc/UTC`), which would prevent the most
+        // common choice from appearing in the dropdown.
+        const zones = Array.from(
+          new Set([
+            'UTC',
+            ...(supportedValuesOf ? supportedValuesOf('timeZone') : []),
+          ])
+        ).sort();
+        const properties = plugin.schema.properties ?? {};
+        properties.timezone = {
+          ...properties.timezone,
+          oneOf: [
+            { type: 'string', const: '', title: 'Browser local time' },
+            ...zones.map(zone => ({
+              type: 'string',
+              const: zone,
+              title: zone,
+            })),
+          ],
+        };
+        plugin.schema.properties = properties;
+        return plugin;
+      },
+    });
+
     let settings: ISettingRegistry.ISettings;
     try {
-      settings = await settingRegistry.load(`${PLUGIN_NAME}:settings`);
+      settings = await settingRegistry.load(pluginId);
     } catch (err: unknown) {
       console.error(
         `jupyterlab-execute-time: Could not load settings, so did not active ${PLUGIN_NAME}: ${err}`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "strict": true,
     "strictNullChecks": false,
     "target": "es2020",
+    "lib": ["DOM", "ES2020", "ES2022.Intl"],
     "types": []
   },
   "include": ["src/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,13 +33,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.21.0":
-  version: 7.28.4
-  resolution: "@babel/runtime@npm:7.28.4"
-  checksum: 934b0a0460f7d06637d93fcd1a44ac49adc33518d17253b5a0b55ff4cb90a45d8fe78bf034b448911dbec7aff2a90b918697559f78d21c99ff8dbadae9565b55
-  languageName: node
-  linkType: hard
-
 "@braintree/sanitize-url@npm:^7.1.1":
   version: 7.1.1
   resolution: "@braintree/sanitize-url@npm:7.1.1"
@@ -342,6 +335,13 @@ __metadata:
     style-mod: ^4.1.0
     w3c-keyname: ^2.2.4
   checksum: b7c6c149ca36459eb0ec0e6f5120010818b553ad41de18680047c90a2db59d37894a980e5b3228007a7869028ee757deecfefb20943f97327b2fcd70ad16e07d
+  languageName: node
+  linkType: hard
+
+"@date-fns/tz@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "@date-fns/tz@npm:1.4.1"
+  checksum: eceefcd68d3fc4f2fa07bdea5a22b05b0075850434cdcc765cea78995bb60cfe72d63c50e925188a1841af8d0a76a16d7d4f139d57d1c16ee03b30b2017a8d2d
   languageName: node
   linkType: hard
 
@@ -3745,21 +3745,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns-tz@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "date-fns-tz@npm:2.0.1"
-  peerDependencies:
-    date-fns: 2.x
-  checksum: 2d2bb3d67f1ac876a7bd3bbe027aba61347d21c74f20a3f014c53d6057a7a1653ed3021c2d9271dc24411ab38f82763fec362c4f24e944465172cd80ee8c4b5f
-  languageName: node
-  linkType: hard
-
-"date-fns@npm:^2.29.3":
-  version: 2.30.0
-  resolution: "date-fns@npm:2.30.0"
-  dependencies:
-    "@babel/runtime": ^7.21.0
-  checksum: f7be01523282e9bb06c0cd2693d34f245247a29098527d4420628966a2d9aad154bd0e90a6b1cf66d37adcb769cd108cf8a7bd49d76db0fb119af5cdd13644f4
+"date-fns@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "date-fns@npm:4.1.0"
+  checksum: fb681b242cccabed45494468f64282a7d375ea970e0adbcc5dcc92dcb7aba49b2081c2c9739d41bf71ce89ed68dd73bebfe06ca35129490704775d091895710b
   languageName: node
   linkType: hard
 
@@ -5765,6 +5754,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jupyterlab-execute-time@workspace:."
   dependencies:
+    "@date-fns/tz": ^1.4.1
     "@jupyterlab/application": ^4.5.0
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/builder": ^4.0.0
@@ -5782,8 +5772,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ~5.55.0
     "@typescript-eslint/parser": ~5.55.0
     chai: ^4.3.7
-    date-fns: ^2.29.3
-    date-fns-tz: ^2.0.0
+    date-fns: ^4.1.0
     eslint: ~8.36.0
     eslint-config-prettier: ~8.7.0
     eslint-plugin-prettier: ~4.2.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -5785,7 +5785,7 @@ __metadata:
     tslint: ^6.1.3
     tslint-config-prettier: ^1.18.0
     tslint-plugin-prettier: ^2.3.0
-    typescript: ~5.0.2
+    typescript: ~5.4.0
     yjs: ^13.5.0
   languageName: unknown
   linkType: soft
@@ -8177,23 +8177,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.0.2":
-  version: 5.0.4
-  resolution: "typescript@npm:5.0.4"
+"typescript@npm:~5.4.0":
+  version: 5.4.5
+  resolution: "typescript@npm:5.4.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
+  checksum: 53c879c6fa1e3bcb194b274d4501ba1985894b2c2692fa079db03c5a5a7140587a1e04e1ba03184605d35f439b40192d9e138eb3279ca8eee313c081c8bcd9b0
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~5.0.2#~builtin<compat/typescript>":
-  version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
+"typescript@patch:typescript@~5.4.0#~builtin<compat/typescript>":
+  version: 5.4.5
+  resolution: "typescript@patch:typescript@npm%3A5.4.5#~builtin<compat/typescript>::version=5.4.5&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
+  checksum: 2373c693f3b328f3b2387c3efafe6d257b057a142f9a79291854b14ff4d5367d3d730810aee981726b677ae0fd8329b23309da3b6aaab8263dbdccf1da07a3ba
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3745,6 +3745,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"date-fns-tz@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "date-fns-tz@npm:2.0.1"
+  peerDependencies:
+    date-fns: 2.x
+  checksum: 2d2bb3d67f1ac876a7bd3bbe027aba61347d21c74f20a3f014c53d6057a7a1653ed3021c2d9271dc24411ab38f82763fec362c4f24e944465172cd80ee8c4b5f
+  languageName: node
+  linkType: hard
+
 "date-fns@npm:^2.29.3":
   version: 2.30.0
   resolution: "date-fns@npm:2.30.0"
@@ -5774,6 +5783,7 @@ __metadata:
     "@typescript-eslint/parser": ~5.55.0
     chai: ^4.3.7
     date-fns: ^2.29.3
+    date-fns-tz: ^2.0.0
     eslint: ~8.36.0
     eslint-config-prettier: ~8.7.0
     eslint-plugin-prettier: ~4.2.1


### PR DESCRIPTION
## Summary

Adds an optional `timezone` setting that lets users render every execute-time
timestamp in a fixed IANA time zone (e.g. `UTC`, `America/New_York`) instead of
the viewer's browser-local zone.

Closes #89.

## Why

Teams sharing notebooks across regions — or reviewing runs that happened on a
remote kernel — want a single consistent timestamp in the cell footer. Today the
extension always renders in browser-local time, which silently shifts the
displayed clock depending on who's looking.

## What changed

- **`schema/settings.json`** — new `timezone` property (string, default `""`).
- **`src/formatters.ts`** — `getTimeString` accepts an optional `timezone`
  argument and routes through `date-fns-tz`'s `formatInTimeZone` when set.
- **`src/ExecuteTimeWidget.ts`** — reads the new setting and forwards it to all
  three `getTimeString` call sites (queued / started / finished).
- **`package.json`** — adds `date-fns-tz@^2.0.0` (companion to the existing
  `date-fns` dependency).

## Backwards compatibility

Default is `""`, which preserves the current behavior exactly: timestamps render
in browser-local time. No migration needed for existing users.

## Testing
<img width="2824" height="550" alt="image" src="https://github.com/user-attachments/assets/3986f910-45d4-411f-8288-6739fbed2ff7" />
